### PR TITLE
Refactor frontend layout with flat design

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.35.0",
+        "@tailwindcss/postcss": "^4.1.13",
         "@types/react": "^19.1.13",
         "@types/react-dom": "^19.1.9",
         "@vitejs/plugin-react": "^5.0.3",
@@ -26,7 +27,7 @@
         "eslint-plugin-react-refresh": "^0.4.20",
         "globals": "^16.4.0",
         "postcss": "^8.5.6",
-        "tailwindcss": "^3.4.17",
+        "tailwindcss": "^4.1.13",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.44.0",
         "vite": "^7.1.5"
@@ -975,22 +976,17 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
-    "node_modules/@isaacs/cliui": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+        "minipass": "^7.0.4"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -1079,17 +1075,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@pkgjs/parseargs": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -1392,6 +1377,282 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.13.tgz",
+      "integrity": "sha512-eq3ouolC1oEFOAvOMOBAmfCIqZBJuvWvvYWh5h5iOYfe1HFC6+GZ6EIL0JdM3/niGRJmnrOc+8gl9/HGUaaptw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.4",
+        "enhanced-resolve": "^5.18.3",
+        "jiti": "^2.5.1",
+        "lightningcss": "1.30.1",
+        "magic-string": "^0.30.18",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.1.13"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.1.13.tgz",
+      "integrity": "sha512-CPgsM1IpGRa880sMbYmG1s4xhAy3xEt1QULgTJGQmZUeNgXFR7s1YxYygmJyBGtou4SyEosGAGEeYqY7R53bIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.4",
+        "tar": "^7.4.3"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.1.13",
+        "@tailwindcss/oxide-darwin-arm64": "4.1.13",
+        "@tailwindcss/oxide-darwin-x64": "4.1.13",
+        "@tailwindcss/oxide-freebsd-x64": "4.1.13",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.1.13",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.1.13",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.1.13",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.1.13",
+        "@tailwindcss/oxide-linux-x64-musl": "4.1.13",
+        "@tailwindcss/oxide-wasm32-wasi": "4.1.13",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.1.13",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.1.13"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.1.13.tgz",
+      "integrity": "sha512-BrpTrVYyejbgGo57yc8ieE+D6VT9GOgnNdmh5Sac6+t0m+v+sKQevpFVpwX3pBrM2qKrQwJ0c5eDbtjouY/+ew==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.1.13.tgz",
+      "integrity": "sha512-YP+Jksc4U0KHcu76UhRDHq9bx4qtBftp9ShK/7UGfq0wpaP96YVnnjFnj3ZFrUAjc5iECzODl/Ts0AN7ZPOANQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.1.13.tgz",
+      "integrity": "sha512-aAJ3bbwrn/PQHDxCto9sxwQfT30PzyYJFG0u/BWZGeVXi5Hx6uuUOQEI2Fa43qvmUjTRQNZnGqe9t0Zntexeuw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.1.13.tgz",
+      "integrity": "sha512-Wt8KvASHwSXhKE/dJLCCWcTSVmBj3xhVhp/aF3RpAhGeZ3sVo7+NTfgiN8Vey/Fi8prRClDs6/f0KXPDTZE6nQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.1.13.tgz",
+      "integrity": "sha512-mbVbcAsW3Gkm2MGwA93eLtWrwajz91aXZCNSkGTx/R5eb6KpKD5q8Ueckkh9YNboU8RH7jiv+ol/I7ZyQ9H7Bw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.1.13.tgz",
+      "integrity": "sha512-wdtfkmpXiwej/yoAkrCP2DNzRXCALq9NVLgLELgLim1QpSfhQM5+ZxQQF8fkOiEpuNoKLp4nKZ6RC4kmeFH0HQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.1.13.tgz",
+      "integrity": "sha512-hZQrmtLdhyqzXHB7mkXfq0IYbxegaqTmfa1p9MBj72WPoDD3oNOh1Lnxf6xZLY9C3OV6qiCYkO1i/LrzEdW2mg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.13.tgz",
+      "integrity": "sha512-uaZTYWxSXyMWDJZNY1Ul7XkJTCBRFZ5Fo6wtjrgBKzZLoJNrG+WderJwAjPzuNZOnmdrVg260DKwXCFtJ/hWRQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.1.13.tgz",
+      "integrity": "sha512-oXiPj5mi4Hdn50v5RdnuuIms0PVPI/EG4fxAfFiIKQh5TgQgX7oSuDWntHW7WNIi/yVLAiS+CRGW4RkoGSSgVQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.1.13.tgz",
+      "integrity": "sha512-+LC2nNtPovtrDwBc/nqnIKYh/W2+R69FA0hgoeOn64BdCX522u19ryLh3Vf3F8W49XBcMIxSe665kwy21FkhvA==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.5",
+        "@emnapi/runtime": "^1.4.5",
+        "@emnapi/wasi-threads": "^1.0.4",
+        "@napi-rs/wasm-runtime": "^0.2.12",
+        "@tybys/wasm-util": "^0.10.0",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.13.tgz",
+      "integrity": "sha512-dziTNeQXtoQ2KBXmrjCxsuPk3F3CQ/yb7ZNZNA+UkNTeiTGgfeh+gH5Pi7mRncVgcPD2xgHvkFCh/MhZWSgyQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.13.tgz",
+      "integrity": "sha512-3+LKesjXydTkHk5zXX01b5KMzLV1xl2mcktBJkje7rhFUpUlYJy7IMOLqjIRQncLTa1WZZiFY/foAeB5nmaiTw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/postcss": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.1.13.tgz",
+      "integrity": "sha512-HLgx6YSFKJT7rJqh9oJs/TkBFhxuMOfUKSBEPYwV+t78POOBsdQ7crhZLzwcH3T0UyUuOzU/GK5pk5eKr3wCiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "@tailwindcss/node": "4.1.13",
+        "@tailwindcss/oxide": "4.1.13",
+        "postcss": "^8.4.41",
+        "tailwindcss": "4.1.13"
+      }
     },
     "node_modules/@tanstack/query-core": {
       "version": "5.89.0",
@@ -1830,19 +2091,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -1858,34 +2106,6 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
-    },
-    "node_modules/any-promise": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/anymatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
-      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/arg": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
-      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -1964,19 +2184,6 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
-      }
-    },
-    "node_modules/binary-extensions": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
-      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/brace-expansion": {
@@ -2060,16 +2267,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/camelcase-css": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
-      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001741",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001741.tgz",
@@ -2108,42 +2305,14 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": ">= 8.10.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/chokidar/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
+        "node": ">=18"
       }
     },
     "node_modules/color-convert": {
@@ -2176,16 +2345,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/commander": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/concat-map": {
@@ -2224,19 +2383,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/cssesc": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
-      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "cssesc": "bin/cssesc"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/csstype": {
@@ -2286,25 +2432,9 @@
       "integrity": "sha512-vEtk+OcP7VBRtQZ1EJ3bdgzSfBjgnEalLTp5zjJrS+2Z1w2KZly4SBdac/WDU3hhsNAZ9E8SC96ME4Ey8MZ7cg==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/didyoumean": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
-      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/dlv": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
-      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -2320,13 +2450,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/eastasianwidth": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.218",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.218.tgz",
@@ -2334,12 +2457,19 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+    "node_modules/enhanced-resolve": {
+      "version": "5.18.3",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.3.tgz",
+      "integrity": "sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
@@ -2774,23 +2904,6 @@
         }
       }
     },
-    "node_modules/foreground-child": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
-      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "cross-spawn": "^7.0.6",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/form-data": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
@@ -2892,27 +3005,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -2924,32 +3016,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/globals": {
@@ -2976,6 +3042,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
@@ -3070,35 +3143,6 @@
         "node": ">=0.8.19"
       }
     },
-    "node_modules/is-binary-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "binary-extensions": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3107,16 +3151,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -3149,30 +3183,12 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
     "node_modules/jiti": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.5.1.tgz",
       "integrity": "sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -3274,8 +3290,6 @@
       "integrity": "sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==",
       "dev": true,
       "license": "MPL-2.0",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -3312,7 +3326,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3334,7 +3347,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3356,7 +3368,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3378,7 +3389,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3400,7 +3410,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3422,7 +3431,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3444,7 +3452,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3466,7 +3473,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3488,7 +3494,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3510,7 +3515,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3518,26 +3522,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       }
-    },
-    "node_modules/lilconfig": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
-      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antonk52"
-      }
-    },
-    "node_modules/lines-and-columns": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -3570,6 +3554,16 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.19",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
+      "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/math-intrinsics": {
@@ -3649,24 +3643,41 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/minizlib": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.2.tgz",
+      "integrity": "sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/mz": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
-      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "any-promise": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "thenify-all": "^1.0.0"
-      }
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -3701,16 +3712,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/normalize-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/normalize-range": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
@@ -3719,26 +3720,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object-hash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
-      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/optionator": {
@@ -3791,13 +3772,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/package-json-from-dist": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0"
-    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -3831,37 +3805,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -3880,26 +3823,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/pify": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/pirates": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
-      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/postcss": {
@@ -3929,126 +3852,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/postcss-import": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
-      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss-value-parser": "^4.0.0",
-        "read-cache": "^1.0.0",
-        "resolve": "^1.1.7"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.0.0"
-      }
-    },
-    "node_modules/postcss-js": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
-      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "camelcase-css": "^2.0.1"
-      },
-      "engines": {
-        "node": "^12 || ^14 || >= 16"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.21"
-      }
-    },
-    "node_modules/postcss-load-config": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
-      "integrity": "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "lilconfig": "^3.0.0",
-        "yaml": "^2.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      },
-      "peerDependencies": {
-        "postcss": ">=8.0.9",
-        "ts-node": ">=9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "postcss": {
-          "optional": true
-        },
-        "ts-node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/postcss-nested": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
-      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "postcss-selector-parser": "^6.1.1"
-      },
-      "engines": {
-        "node": ">=12.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.14"
-      }
-    },
-    "node_modules/postcss-selector-parser": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
-      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/postcss-value-parser": {
@@ -4172,50 +3975,6 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
-      }
-    },
-    "node_modules/read-cache": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
-      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pify": "^2.3.0"
-      }
-    },
-    "node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      }
-    },
-    "node_modules/resolve": {
-      "version": "1.22.10",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
-      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-core-module": "^2.16.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/resolve-from": {
@@ -4349,19 +4108,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4370,110 +4116,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/string-width-cjs": {
-      "name": "string-width",
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/string-width-cjs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/strip-ansi-cjs": {
-      "name": "strip-ansi",
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -4489,29 +4131,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/sucrase": {
-      "version": "3.35.0",
-      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
-      "integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.2",
-        "commander": "^4.0.0",
-        "glob": "^10.3.10",
-        "lines-and-columns": "^1.1.6",
-        "mz": "^2.7.0",
-        "pirates": "^4.0.1",
-        "ts-interface-checker": "^0.1.9"
-      },
-      "bin": {
-        "sucrase": "bin/sucrase",
-        "sucrase-node": "bin/sucrase-node"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -4525,88 +4144,53 @@
         "node": ">=8"
       }
     },
-    "node_modules/supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+    "node_modules/tailwindcss": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.13.tgz",
+      "integrity": "sha512-i+zidfmTqtwquj4hMEwdjshYYgMbOrPzb9a0M3ZgNa0JMoZeFC6bxZvO8yr8ozS6ix2SDz0+mvryPeBs2TFE+w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.3.tgz",
+      "integrity": "sha512-ZL6DDuAlRlLGghwcfmSn9sK3Hr6ArtyudlSAiCqQ6IfE+b+HHbydbYDIG15IfS5do+7XQQBdBiubF/cV2dnDzg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 0.4"
+        "node": ">=6"
       },
       "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/tailwindcss": {
-      "version": "3.4.17",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
-      "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
+    "node_modules/tar": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
+      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
       "dev": true,
-      "license": "MIT",
+      "license": "ISC",
       "dependencies": {
-        "@alloc/quick-lru": "^5.2.0",
-        "arg": "^5.0.2",
-        "chokidar": "^3.6.0",
-        "didyoumean": "^1.2.2",
-        "dlv": "^1.1.3",
-        "fast-glob": "^3.3.2",
-        "glob-parent": "^6.0.2",
-        "is-glob": "^4.0.3",
-        "jiti": "^1.21.6",
-        "lilconfig": "^3.1.3",
-        "micromatch": "^4.0.8",
-        "normalize-path": "^3.0.0",
-        "object-hash": "^3.0.0",
-        "picocolors": "^1.1.1",
-        "postcss": "^8.4.47",
-        "postcss-import": "^15.1.0",
-        "postcss-js": "^4.0.1",
-        "postcss-load-config": "^4.0.2",
-        "postcss-nested": "^6.2.0",
-        "postcss-selector-parser": "^6.1.2",
-        "resolve": "^1.22.8",
-        "sucrase": "^3.35.0"
-      },
-      "bin": {
-        "tailwind": "lib/cli.js",
-        "tailwindcss": "lib/cli.js"
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.0.1",
+        "mkdirp": "^3.0.1",
+        "yallist": "^5.0.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18"
       }
     },
-    "node_modules/tailwindcss/node_modules/jiti": {
-      "version": "1.21.7",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
-      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+    "node_modules/tar/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
       "dev": true,
-      "license": "MIT",
-      "bin": {
-        "jiti": "bin/jiti.js"
-      }
-    },
-    "node_modules/thenify": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
-      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "any-promise": "^1.0.0"
-      }
-    },
-    "node_modules/thenify-all": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
-      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "thenify": ">= 3.1.0 < 4"
-      },
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": ">=0.8"
+        "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
@@ -4682,13 +4266,6 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
-    },
-    "node_modules/ts-interface-checker": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
-      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
-      "dev": true,
-      "license": "Apache-2.0"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -4781,13 +4358,6 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "7.1.5",
@@ -4921,101 +4491,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs": {
-      "name": "wrap-ansi",
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -5029,6 +4504,8 @@
       "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/frontend/src/components/ArticleList.tsx
+++ b/frontend/src/components/ArticleList.tsx
@@ -1,0 +1,65 @@
+import { Link } from "react-router-dom";
+import type { Article } from "../api/hooks";
+import { cn } from "../lib/cn";
+
+type ArticleListProps = {
+  articles: Article[];
+  className?: string;
+  showSummary?: boolean;
+  emptyHint?: string;
+};
+
+export const ArticleList = ({
+  articles,
+  className,
+  showSummary = true,
+  emptyHint = "暂无文章",
+}: ArticleListProps) => {
+  if (articles.length === 0) {
+    return <p className="text-sm text-slate-500">{emptyHint}</p>;
+  }
+
+  return (
+    <ul className={cn("space-y-3", className)}>
+      {articles.map((article) => (
+        <li
+          key={article.id}
+          className="group rounded-2xl border border-slate-200 bg-white/90 p-4 transition hover:border-primary/40"
+        >
+          <div className="flex flex-col gap-3">
+            <div className="space-y-1">
+              <Link
+                to={`/articles/${article.slug}`}
+                className="text-base font-semibold text-slate-900 transition group-hover:text-primary"
+              >
+                {article.title}
+              </Link>
+              {article.published_at ? (
+                <p className="text-xs text-slate-400">
+                  {new Date(article.published_at).toLocaleDateString()}
+                </p>
+              ) : null}
+            </div>
+            {showSummary && article.summary ? (
+              <p className="text-sm text-slate-600 line-clamp-3">{article.summary}</p>
+            ) : null}
+            <div className="flex items-center gap-2 text-xs font-medium text-primary">
+              <span>阅读全文</span>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 20 20"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={1.5}
+                className="h-3.5 w-3.5"
+                aria-hidden="true"
+              >
+                <path d="m7.5 5 5 5-5 5" />
+              </svg>
+            </div>
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+};

--- a/frontend/src/components/PageHeader.tsx
+++ b/frontend/src/components/PageHeader.tsx
@@ -1,0 +1,22 @@
+import type { ReactNode } from "react";
+
+type PageHeaderProps = {
+  title: string;
+  description?: string;
+  action?: ReactNode;
+  className?: string;
+};
+
+export const PageHeader = ({ title, description, action, className = "" }: PageHeaderProps) => {
+  return (
+    <header
+      className={`flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between ${className}`.trim()}
+    >
+      <div className="space-y-2">
+        <h1 className="text-3xl font-semibold text-slate-900">{title}</h1>
+        {description ? <p className="max-w-2xl text-sm text-slate-500">{description}</p> : null}
+      </div>
+      {action ? <div className="flex-shrink-0">{action}</div> : null}
+    </header>
+  );
+};

--- a/frontend/src/components/QuickArchive.tsx
+++ b/frontend/src/components/QuickArchive.tsx
@@ -1,5 +1,6 @@
 import { Link } from "react-router-dom";
 import { useArchive } from "../api/hooks";
+import { cn } from "../lib/cn";
 
 type QuickArchiveProps = {
   className?: string;
@@ -7,46 +8,43 @@ type QuickArchiveProps = {
 
 export const QuickArchive = ({ className = "" }: QuickArchiveProps) => {
   const { data, isLoading } = useArchive(1);
-  const containerClasses =
-    "rounded-3xl border border-slate-200 bg-white/95 p-6 shadow-sm transition-shadow hover:shadow-md";
 
   return (
-    <div className={`${containerClasses} ${className}`.trim()}>
-      <div className="flex items-start justify-between gap-3">
+    <section
+      className={cn(
+        "rounded-2xl border border-slate-200 bg-white p-6",
+        "transition hover:border-primary/40",
+        className,
+      )}
+    >
+      <div className="flex items-center justify-between gap-3">
         <div className="flex items-center gap-3">
-          <span className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 text-primary">
-            📰
-          </span>
+          <span className="flex h-10 w-10 items-center justify-center rounded-xl bg-primary/10 text-primary">📰</span>
           <div>
-            <h3 className="text-base font-semibold text-slate-900">往期精选</h3>
-            <p className="text-xs text-slate-500">最新六篇文章速览</p>
+            <h3 className="text-sm font-semibold text-slate-900">往期精选</h3>
+            <p className="text-xs text-slate-500">最新六篇文章</p>
           </div>
         </div>
-        <Link
-          to="/archive"
-          className="text-sm font-medium text-primary transition hover:text-primary/80"
-        >
+        <Link to="/archive" className="text-xs font-medium text-primary hover:text-primary/80">
           查看全部
         </Link>
       </div>
 
-      <div className="mt-5">
+      <div className="mt-5 space-y-2">
         {isLoading && <p className="text-sm text-slate-500">加载中...</p>}
-        {!isLoading && (!data || data.items.length === 0) && (
+        {!isLoading && (!data || data.items.length === 0) ? (
           <p className="text-sm text-slate-500">暂无文章</p>
-        )}
-        {!isLoading && data && data.items.length > 0 && (
+        ) : null}
+        {!isLoading && data?.items.length ? (
           <ul className="space-y-2">
             {data.items.slice(0, 6).map((article) => (
               <li key={article.id}>
                 <Link
                   to={`/articles/${article.slug}`}
-                  className="group flex items-center justify-between gap-3 rounded-xl border border-transparent px-3 py-2 transition hover:border-primary/20 hover:bg-primary/5"
+                  className="group flex items-center justify-between gap-3 rounded-xl px-3 py-2 transition hover:bg-primary/5"
                 >
                   <div>
-                    <p className="text-sm font-medium text-slate-800 group-hover:text-primary">
-                      {article.title}
-                    </p>
+                    <p className="text-sm font-medium text-slate-800 group-hover:text-primary">{article.title}</p>
                     <p className="text-xs text-slate-400">
                       {article.published_at
                         ? new Date(article.published_at).toLocaleDateString()
@@ -68,8 +66,8 @@ export const QuickArchive = ({ className = "" }: QuickArchiveProps) => {
               </li>
             ))}
           </ul>
-        )}
+        ) : null}
       </div>
-    </div>
+    </section>
   );
 };

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -15,6 +15,9 @@ body,
 
   body {
     font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    margin: 0;
+    background-color: #f8fafc;
+    color: #0f172a;
   }
 
   h1,

--- a/frontend/src/layouts/MainLayout.tsx
+++ b/frontend/src/layouts/MainLayout.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Link, NavLink, Outlet } from "react-router-dom";
 import { useAuthStore } from "../store/auth";
+import { cn } from "../lib/cn";
 
 const navItems = [
   { to: "/", label: "首页" },
@@ -15,11 +16,10 @@ export const MainLayout = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
   const navClassName = ({ isActive }: { isActive: boolean }) =>
-    `inline-flex items-center rounded-full px-4 py-2 text-sm font-medium transition ${
-      isActive
-        ? "bg-white text-primary shadow-sm"
-        : "text-slate-600 hover:bg-white hover:text-slate-900"
-    }`;
+    cn(
+      "inline-flex items-center rounded-lg px-3 py-2 text-sm font-medium transition-colors",
+      isActive ? "bg-slate-100 text-slate-900" : "text-slate-600 hover:bg-slate-100 hover:text-slate-900",
+    );
 
   const roleLabels: Record<string, string> = {
     admin: "管理员",
@@ -36,31 +36,31 @@ export const MainLayout = () => {
   };
 
   return (
-    <div className="flex min-h-screen flex-col bg-slate-100/60">
-      <header className="sticky top-0 z-40 border-b border-slate-200 bg-white/90 backdrop-blur">
+    <div className="flex min-h-screen flex-col bg-slate-100/70">
+      <header className="sticky top-0 z-40 border-b border-slate-200 bg-white/95 backdrop-blur">
         <div className="mx-auto flex w-full max-w-6xl items-center justify-between gap-4 px-4 py-4 sm:px-6">
-          <Link to="/" className="flex items-center gap-3">
-            <span className="text-xl font-semibold text-primary">HFI 学习中心</span>
-            <span className="hidden text-sm text-slate-500 sm:inline">Learning Hub</span>
+          <Link to="/" className="flex items-center gap-3 text-slate-900">
+            <span className="text-xl font-semibold">HFI 学习中心</span>
+            <span className="hidden text-xs text-slate-500 sm:inline">Learning Hub</span>
           </Link>
-          <nav className="hidden items-center gap-1 rounded-full bg-slate-100 p-1 md:flex">
+          <nav className="hidden items-center gap-1 md:flex">
             {navItems.map((item) => (
               <NavLink key={item.to} to={item.to} className={navClassName} onClick={handleCloseMenu}>
                 {item.label}
               </NavLink>
             ))}
-            {user?.role === "admin" && (
+            {user?.role === "admin" ? (
               <NavLink to="/admin" className={navClassName} onClick={handleCloseMenu}>
                 管理后台
               </NavLink>
-            )}
+            ) : null}
           </nav>
           <div className="flex items-center gap-3">
             {user ? (
               <div className="flex items-center gap-3">
-                <div className="hidden items-center gap-2 rounded-full bg-primary/10 px-3 py-1.5 text-sm font-medium text-primary sm:flex">
+                <div className="hidden items-center gap-2 rounded-xl bg-slate-100 px-3 py-1.5 text-sm font-medium text-slate-700 sm:flex">
                   <span>{user.name}</span>
-                  <span className="rounded-full bg-white/70 px-2 py-0.5 text-xs text-primary/80">
+                  <span className="rounded-full bg-white px-2 py-0.5 text-xs text-slate-500">
                     {roleLabels[user.role] ?? user.role}
                   </span>
                 </div>
@@ -69,7 +69,7 @@ export const MainLayout = () => {
                     void logout();
                     handleCloseMenu();
                   }}
-                  className="inline-flex items-center rounded-full border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 transition hover:border-primary hover:text-primary"
+                  className="inline-flex items-center rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-600 transition hover:border-primary hover:text-primary"
                 >
                   退出
                 </button>
@@ -78,14 +78,14 @@ export const MainLayout = () => {
               <Link
                 to="/login"
                 onClick={handleCloseMenu}
-                className="inline-flex items-center rounded-full bg-primary px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-primary/90"
+                className="inline-flex items-center rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-white transition hover:bg-primary/90"
               >
                 登录
               </Link>
             )}
             <button
               type="button"
-              className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-slate-300 text-slate-600 transition hover:border-primary hover:text-primary md:hidden"
+              className="inline-flex h-10 w-10 items-center justify-center rounded-lg border border-slate-300 text-slate-600 transition hover:border-primary hover:text-primary md:hidden"
               onClick={handleToggleMenu}
               aria-label="切换导航"
             >
@@ -107,19 +107,28 @@ export const MainLayout = () => {
             </button>
           </div>
         </div>
-        {isMenuOpen && (
+        {isMenuOpen ? (
           <nav className="border-t border-slate-200 bg-white/95 md:hidden">
             <div className="mx-auto flex max-w-6xl flex-col gap-1 px-4 py-4">
               {navItems.map((item) => (
-                <NavLink key={item.to} to={item.to} className="rounded-lg px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100" onClick={handleCloseMenu}>
+                <NavLink
+                  key={item.to}
+                  to={item.to}
+                  className="rounded-lg px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100"
+                  onClick={handleCloseMenu}
+                >
                   {item.label}
                 </NavLink>
               ))}
-              {user?.role === "admin" && (
-                <NavLink to="/admin" className="rounded-lg px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100" onClick={handleCloseMenu}>
+              {user?.role === "admin" ? (
+                <NavLink
+                  to="/admin"
+                  className="rounded-lg px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100"
+                  onClick={handleCloseMenu}
+                >
                   管理后台
                 </NavLink>
-              )}
+              ) : null}
               <div className="pt-2">
                 {user ? (
                   <button
@@ -127,7 +136,7 @@ export const MainLayout = () => {
                       void logout();
                       handleCloseMenu();
                     }}
-                    className="w-full rounded-lg bg-primary px-3 py-2 text-sm font-medium text-white shadow-sm hover:bg-primary/90"
+                    className="w-full rounded-lg bg-primary px-3 py-2 text-sm font-semibold text-white hover:bg-primary/90"
                   >
                     退出登录
                   </button>
@@ -143,7 +152,7 @@ export const MainLayout = () => {
               </div>
             </div>
           </nav>
-        )}
+        ) : null}
       </header>
       <main className="flex-1">
         <div className="relative mx-auto w-full max-w-6xl px-4 py-10 sm:px-6 lg:py-12">

--- a/frontend/src/lib/cn.ts
+++ b/frontend/src/lib/cn.ts
@@ -1,0 +1,2 @@
+export const cn = (...classes: Array<string | false | null | undefined>) =>
+  classes.filter(Boolean).join(" ");

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -4,6 +4,7 @@ import {
   useApproveResource,
   useUpdateBookingStatus,
 } from "../api/hooks";
+import { PageHeader } from "../components/PageHeader";
 
 export const AdminDashboard = () => {
   const { data: pendingResources } = usePendingResources();
@@ -13,32 +14,34 @@ export const AdminDashboard = () => {
 
   return (
     <div className="space-y-8">
-      <header>
-        <h1 className="text-3xl font-semibold text-slate-800">管理员控制台</h1>
-        <p className="mt-2 text-sm text-slate-500">审核资料与管理导师预约。</p>
-      </header>
+      <PageHeader title="管理员控制台" description="审核资料并管理导师预约安排。" />
 
-      <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-        <h2 className="text-xl font-semibold text-slate-800">待审核资料</h2>
+      <section className="rounded-2xl border border-slate-200 bg-white p-6">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h2 className="text-lg font-semibold text-slate-900">待审核资料</h2>
+            <p className="text-xs text-slate-500">核对文件信息，快速同步给同学。</p>
+          </div>
+        </div>
         <div className="mt-4 space-y-3">
           {pendingResources && pendingResources.length > 0 ? (
             pendingResources.map((resource) => (
-              <div key={resource.id} className="rounded border border-slate-200 p-4">
+              <div key={resource.id} className="rounded-xl border border-slate-200 p-4 text-sm text-slate-600">
                 <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                   <div>
-                    <p className="font-medium text-slate-700">{resource.title}</p>
-                    <p className="text-sm text-slate-500">{resource.description}</p>
+                    <p className="font-medium text-slate-800">{resource.title}</p>
+                    <p className="text-xs text-slate-500">{resource.description}</p>
                   </div>
                   <div className="flex gap-2">
                     <button
                       onClick={() => approveResource.mutate({ id: resource.id, action: "approve" })}
-                      className="rounded bg-primary px-3 py-1 text-sm text-white hover:bg-primary/90"
+                      className="rounded-lg bg-primary px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-white hover:bg-primary/90"
                     >
                       审核通过
                     </button>
                     <button
                       onClick={() => approveResource.mutate({ id: resource.id, action: "reject" })}
-                      className="rounded bg-red-500 px-3 py-1 text-sm text-white hover:bg-red-600"
+                      className="rounded-lg bg-red-500 px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-white hover:bg-red-600"
                     >
                       驳回
                     </button>
@@ -52,28 +55,33 @@ export const AdminDashboard = () => {
         </div>
       </section>
 
-      <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-        <h2 className="text-xl font-semibold text-slate-800">预约管理</h2>
+      <section className="rounded-2xl border border-slate-200 bg-white p-6">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h2 className="text-lg font-semibold text-slate-900">预约管理</h2>
+            <p className="text-xs text-slate-500">更新预约状态，确保导师与同学及时知晓。</p>
+          </div>
+        </div>
         <div className="mt-4 space-y-3">
           {adminBookings && adminBookings.length > 0 ? (
             adminBookings.map((booking) => (
-              <div key={booking.id} className="rounded border border-slate-200 p-4">
+              <div key={booking.id} className="rounded-xl border border-slate-200 p-4 text-sm text-slate-600">
                 <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                   <div>
-                    <p className="font-medium text-slate-700">
+                    <p className="font-medium text-slate-800">
                       {booking.student_name ?? ""} → {booking.mentor_name}
                     </p>
-                    <p className="text-sm text-slate-500">{booking.subject}</p>
+                    <p className="text-xs text-slate-500">{booking.subject}</p>
                     <p className="text-xs text-slate-400">
                       {new Date(booking.start_time).toLocaleString()} - {new Date(booking.end_time).toLocaleString()}
                     </p>
                   </div>
-                  <div className="flex gap-2">
+                  <div className="flex flex-wrap gap-2">
                     {(["approved", "rejected", "cancelled"] as const).map((status) => (
                       <button
                         key={status}
                         onClick={() => updateBookingStatus.mutate({ id: booking.id, status })}
-                        className="rounded border border-slate-300 px-3 py-1 text-xs uppercase tracking-wide hover:border-primary"
+                        className="rounded-lg border border-slate-300 px-3 py-1 text-xs uppercase tracking-wide hover:border-primary"
                       >
                         {status}
                       </button>

--- a/frontend/src/pages/ArchivePage.tsx
+++ b/frontend/src/pages/ArchivePage.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
-import { Link } from "react-router-dom";
 import { useArchive } from "../api/hooks";
+import { ArticleList } from "../components/ArticleList";
+import { PageHeader } from "../components/PageHeader";
 
 export const ArchivePage = () => {
   const [page, setPage] = useState(1);
@@ -9,58 +10,40 @@ export const ArchivePage = () => {
   const totalPages = data ? Math.ceil(data.total / data.perPage) : 1;
 
   return (
-    <div className="space-y-6">
-      <header className="flex items-center justify-between">
-        <h1 className="text-3xl font-semibold text-slate-800">往期文章</h1>
-        <p className="text-sm text-slate-500">回顾历次分享与公告</p>
-      </header>
+    <div className="space-y-8">
+      <PageHeader title="往期文章" description="回顾历次分享与公告，随时查阅需要的内容。" />
 
-      {isLoading && <div className="text-slate-500">加载中...</div>}
+      <section className="rounded-2xl border border-slate-200 bg-white p-6">
+        {isLoading ? (
+          <p className="text-sm text-slate-500">加载中...</p>
+        ) : data ? (
+          <ArticleList articles={data.items} showSummary emptyHint="暂无历史文章" />
+        ) : (
+          <p className="text-sm text-slate-500">暂无文章</p>
+        )}
+      </section>
 
-      {data && (
-        <div className="space-y-4">
-          {data.items.map((article) => (
-            <article
-              key={article.id}
-              className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm hover:border-primary/60"
-            >
-              <h2 className="text-2xl font-semibold text-slate-800">{article.title}</h2>
-              <p className="mt-2 text-sm text-slate-500">
-                {article.published_at ? new Date(article.published_at).toLocaleString() : ""}
-              </p>
-              <p className="mt-3 text-slate-600 line-clamp-3">{article.summary}</p>
-              <Link
-                to={`/articles/${article.slug}`}
-                className="mt-4 inline-flex items-center text-sm font-medium text-primary hover:underline"
-              >
-                阅读详情
-              </Link>
-            </article>
-          ))}
-        </div>
-      )}
-
-      {totalPages > 1 && (
-        <div className="flex items-center justify-between border-t border-slate-200 pt-6">
+      {totalPages > 1 ? (
+        <div className="flex items-center justify-between rounded-2xl border border-slate-200 bg-white p-4 text-sm text-slate-600">
           <button
-            className="rounded border border-slate-300 px-4 py-2 text-sm disabled:opacity-40"
+            className="rounded-lg border border-slate-300 px-3 py-2 disabled:opacity-40"
             onClick={() => setPage((p) => Math.max(1, p - 1))}
             disabled={page === 1}
           >
             上一页
           </button>
-          <span className="text-sm text-slate-500">
+          <span>
             第 {page} / {totalPages} 页
           </span>
           <button
-            className="rounded border border-slate-300 px-4 py-2 text-sm disabled:opacity-40"
+            className="rounded-lg border border-slate-300 px-3 py-2 disabled:opacity-40"
             onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
             disabled={page === totalPages}
           >
             下一页
           </button>
         </div>
-      )}
+      ) : null}
     </div>
   );
 };

--- a/frontend/src/pages/ArticleDetailPage.tsx
+++ b/frontend/src/pages/ArticleDetailPage.tsx
@@ -1,29 +1,31 @@
 import { useParams } from "react-router-dom";
 import { useArticle } from "../api/hooks";
+import { PageHeader } from "../components/PageHeader";
 
 export const ArticleDetailPage = () => {
   const { slug } = useParams<{ slug: string }>();
   const { data: article, isLoading, isError } = useArticle(slug ?? "");
 
   if (isLoading) {
-    return <div className="text-slate-500">加载中...</div>;
+    return <div className="text-sm text-slate-500">加载中...</div>;
   }
 
   if (isError || !article) {
-    return <div className="text-slate-500">文章不存在</div>;
+    return <div className="text-sm text-slate-500">文章不存在</div>;
   }
 
   return (
-    <article className="prose prose-slate max-w-none rounded-2xl border border-slate-200 bg-white p-8 shadow-sm">
-      <p className="text-sm text-slate-500">
-        发布于 {article.published_at ? new Date(article.published_at).toLocaleString() : "未知"}
-      </p>
-      <h1>{article.title}</h1>
-      <p className="text-lg text-slate-600">{article.summary}</p>
-      <div
-        className="mt-6 space-y-4"
-        dangerouslySetInnerHTML={{ __html: article.content ?? "" }}
-      />
-    </article>
+    <div className="space-y-6">
+      <PageHeader title={article.title} description={article.summary} />
+      <article className="rounded-2xl border border-slate-200 bg-white p-8">
+        <p className="text-xs text-slate-400">
+          发布于 {article.published_at ? new Date(article.published_at).toLocaleString() : "未知时间"}
+        </p>
+        <div
+          className="prose prose-slate mt-6 max-w-none text-slate-700"
+          dangerouslySetInnerHTML={{ __html: article.content ?? "" }}
+        />
+      </article>
+    </div>
   );
 };

--- a/frontend/src/pages/BookingsPage.tsx
+++ b/frontend/src/pages/BookingsPage.tsx
@@ -2,6 +2,7 @@ import type { FormEvent } from "react";
 import { useMemo, useState } from "react";
 import { useAuthStore } from "../store/auth";
 import { useCreateBooking, useBookings, useMentors } from "../api/hooks";
+import { PageHeader } from "../components/PageHeader";
 
 export const BookingsPage = () => {
   const { user } = useAuthStore();
@@ -50,148 +51,158 @@ export const BookingsPage = () => {
   };
 
   return (
-    <div className="grid gap-8 lg:grid-cols-[2fr_1fr]">
-      <section className="space-y-6">
-        <header>
-          <h1 className="text-3xl font-semibold text-slate-800">导师预约</h1>
-          <p className="mt-2 text-sm text-slate-500">
-            选择导师、科目与时间，管理员审核后您的预约将生效。
-          </p>
-        </header>
+    <div className="space-y-8">
+      <PageHeader
+        title="导师预约"
+        description="选择导师、科目与时间，管理员审核后即可确认预约安排。"
+      />
 
-        <form onSubmit={handleSubmit} className="space-y-4 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-          <div className="grid gap-4 sm:grid-cols-2">
-            <label className="text-sm text-slate-700">
-              导师
-              <select
-                className="mt-1 w-full rounded border border-slate-300 px-3 py-2"
-                value={formState.mentor_id}
-                onChange={(event) => setFormState((prev) => ({ ...prev, mentor_id: event.target.value }))}
-                required
-              >
-                <option value="">请选择导师</option>
-                {mentors?.map((mentor) => (
-                  <option key={mentor.id} value={mentor.id}>
-                    {mentor.name}
-                  </option>
-                ))}
-              </select>
-            </label>
-            <label className="text-sm text-slate-700">
-              科目
-              <input
-                className="mt-1 w-full rounded border border-slate-300 px-3 py-2"
-                value={formState.subject}
-                onChange={(event) => setFormState((prev) => ({ ...prev, subject: event.target.value }))}
-                required
-              />
-            </label>
-            <label className="text-sm text-slate-700">
-              日期
-              <input
-                type="date"
-                className="mt-1 w-full rounded border border-slate-300 px-3 py-2"
-                value={formState.date}
-                onChange={(event) => setFormState((prev) => ({ ...prev, date: event.target.value }))}
-                required
-              />
-            </label>
-            <label className="text-sm text-slate-700">
-              地点
-              <input
-                className="mt-1 w-full rounded border border-slate-300 px-3 py-2"
-                value={formState.location}
-                onChange={(event) => setFormState((prev) => ({ ...prev, location: event.target.value }))}
-                required
-              />
-            </label>
-            <label className="text-sm text-slate-700">
-              开始时间
-              <input
-                type="time"
-                className="mt-1 w-full rounded border border-slate-300 px-3 py-2"
-                value={formState.start}
-                onChange={(event) => setFormState((prev) => ({ ...prev, start: event.target.value }))}
-                required
-              />
-            </label>
-            <label className="text-sm text-slate-700">
-              结束时间
-              <input
-                type="time"
-                className="mt-1 w-full rounded border border-slate-300 px-3 py-2"
-                value={formState.end}
-                onChange={(event) => setFormState((prev) => ({ ...prev, end: event.target.value }))}
-                required
-              />
-            </label>
-          </div>
+      <div className="grid gap-6 lg:grid-cols-[1.6fr_1fr]">
+        <section className="space-y-6">
+          <form onSubmit={handleSubmit} className="rounded-2xl border border-slate-200 bg-white p-6">
+            <h2 className="text-lg font-semibold text-slate-900">提交预约</h2>
+            <p className="mt-1 text-xs text-slate-500">请填写完整信息，确保导师可以快速确认安排。</p>
 
-          {availability.length > 0 && (
-            <div className="rounded border border-primary/30 bg-primary/5 p-3 text-sm text-primary">
-              <p className="font-semibold">导师可预约时段</p>
-              <ul className="mt-2 space-y-1">
-                {availability.map((item) => (
-                  <li key={item.day}>
-                    {item.day}: {item.slots.join(" / ")}
-                  </li>
-                ))}
-              </ul>
+            <div className="mt-4 grid gap-4 sm:grid-cols-2">
+              <label className="text-sm text-slate-700">
+                导师
+                <select
+                  className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2"
+                  value={formState.mentor_id}
+                  onChange={(event) => setFormState((prev) => ({ ...prev, mentor_id: event.target.value }))}
+                  required
+                >
+                  <option value="">请选择导师</option>
+                  {mentors?.map((mentor) => (
+                    <option key={mentor.id} value={mentor.id}>
+                      {mentor.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="text-sm text-slate-700">
+                科目
+                <input
+                  className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2"
+                  value={formState.subject}
+                  onChange={(event) => setFormState((prev) => ({ ...prev, subject: event.target.value }))}
+                  required
+                />
+              </label>
+              <label className="text-sm text-slate-700">
+                日期
+                <input
+                  type="date"
+                  className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2"
+                  value={formState.date}
+                  onChange={(event) => setFormState((prev) => ({ ...prev, date: event.target.value }))}
+                  required
+                />
+              </label>
+              <label className="text-sm text-slate-700">
+                地点
+                <input
+                  className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2"
+                  value={formState.location}
+                  onChange={(event) => setFormState((prev) => ({ ...prev, location: event.target.value }))}
+                  required
+                />
+              </label>
+              <label className="text-sm text-slate-700">
+                开始时间
+                <input
+                  type="time"
+                  className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2"
+                  value={formState.start}
+                  onChange={(event) => setFormState((prev) => ({ ...prev, start: event.target.value }))}
+                  required
+                />
+              </label>
+              <label className="text-sm text-slate-700">
+                结束时间
+                <input
+                  type="time"
+                  className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2"
+                  value={formState.end}
+                  onChange={(event) => setFormState((prev) => ({ ...prev, end: event.target.value }))}
+                  required
+                />
+              </label>
             </div>
-          )}
 
-          {message && <div className="rounded bg-slate-100 px-4 py-2 text-sm text-slate-600">{message}</div>}
+            {availability.length > 0 ? (
+              <div className="mt-4 rounded-xl border border-primary/30 bg-primary/5 p-3 text-sm text-primary">
+                <p className="font-semibold">导师可预约时段</p>
+                <ul className="mt-2 space-y-1">
+                  {availability.map((item) => (
+                    <li key={item.day}>
+                      {item.day}: {item.slots.join(" / ")}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ) : null}
 
-          <button
-            type="submit"
-            className="w-full rounded bg-primary px-4 py-2 font-semibold text-white hover:bg-primary/90"
-            disabled={createBooking.isPending}
-          >
-            {createBooking.isPending ? "提交中..." : "提交预约"}
-          </button>
-        </form>
+            {message ? (
+              <div className="mt-4 rounded-lg border border-slate-200 bg-slate-50 px-4 py-2 text-sm text-slate-600">
+                {message}
+              </div>
+            ) : null}
 
-        <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-          <h2 className="text-xl font-semibold text-slate-800">我的预约</h2>
-          <div className="mt-4 space-y-3">
-            {bookings && bookings.length > 0 ? (
-              bookings.map((booking) => (
-                <div key={booking.id} className="rounded border border-slate-200 p-4">
-                  <div className="flex items-center justify-between">
-                    <p className="text-sm text-slate-600">导师：{booking.mentor_name}</p>
-                    <span className="rounded bg-slate-100 px-2 py-1 text-xs text-slate-500">
-                      状态：{booking.status}
-                    </span>
+            <button
+              type="submit"
+              className="mt-6 w-full rounded-lg bg-primary px-4 py-2 font-semibold text-white hover:bg-primary/90 disabled:opacity-60"
+              disabled={createBooking.isPending}
+            >
+              {createBooking.isPending ? "提交中..." : "提交预约"}
+            </button>
+          </form>
+
+          <section className="rounded-2xl border border-slate-200 bg-white p-6">
+            <h2 className="text-lg font-semibold text-slate-900">我的预约</h2>
+            <div className="mt-4 space-y-3">
+              {bookings && bookings.length > 0 ? (
+                bookings.map((booking) => (
+                  <div key={booking.id} className="rounded-xl border border-slate-200 p-4">
+                    <div className="flex items-center justify-between text-sm text-slate-600">
+                      <span>导师：{booking.mentor_name}</span>
+                      <span className="rounded-full bg-slate-100 px-2 py-0.5 text-xs text-slate-500">
+                        状态：{booking.status}
+                      </span>
+                    </div>
+                    <p className="mt-1 text-sm text-slate-600">科目：{booking.subject}</p>
+                    <p className="text-sm text-slate-600">地点：{booking.location}</p>
+                    <p className="text-xs text-slate-400">
+                      {new Date(booking.start_time).toLocaleString()} - {new Date(booking.end_time).toLocaleString()}
+                    </p>
                   </div>
-                  <p className="mt-1 text-sm text-slate-600">科目：{booking.subject}</p>
-                  <p className="text-sm text-slate-600">地点：{booking.location}</p>
-                  <p className="text-xs text-slate-500">
-                    {new Date(booking.start_time).toLocaleString()} - {new Date(booking.end_time).toLocaleString()}
-                  </p>
-                </div>
-              ))
-            ) : (
-              <p className="text-sm text-slate-500">暂无预约记录</p>
-            )}
-          </div>
+                ))
+              ) : (
+                <p className="text-sm text-slate-500">暂无预约记录</p>
+              )}
+            </div>
+          </section>
         </section>
-      </section>
 
-      <aside className="space-y-4">
-        <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-          <h3 className="text-lg font-semibold text-slate-800">导师团队</h3>
-          <ul className="mt-3 space-y-3">
-            {mentors?.map((mentor) => (
-              <li key={mentor.id}>
-                <p className="font-medium text-slate-700">{mentor.name}</p>
-                {mentor.subjects.length > 0 && (
-                  <p className="text-xs text-slate-500">擅长：{mentor.subjects.join("、")}</p>
-                )}
-              </li>
-            ))}
-          </ul>
-        </div>
-      </aside>
+        <aside className="space-y-4">
+          <section className="rounded-2xl border border-slate-200 bg-white p-6">
+            <h3 className="text-lg font-semibold text-slate-900">导师团队</h3>
+            <ul className="mt-3 space-y-3 text-sm text-slate-600">
+              {mentors?.map((mentor) => (
+                <li key={mentor.id} className="rounded-xl border border-slate-200 px-3 py-3">
+                  <p className="font-medium text-slate-800">{mentor.name}</p>
+                  {mentor.subjects.length > 0 ? (
+                    <p className="text-xs text-slate-500">擅长：{mentor.subjects.join("、")}</p>
+                  ) : null}
+                  {mentor.locations.length > 0 ? (
+                    <p className="text-xs text-slate-400">可预约地点：{mentor.locations.join("、")}</p>
+                  ) : null}
+                </li>
+              ))}
+            </ul>
+          </section>
+        </aside>
+      </div>
     </div>
   );
 };

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,5 +1,7 @@
 import { Link } from "react-router-dom";
 import { useHomepageFeed } from "../api/hooks";
+import { ArticleList } from "../components/ArticleList";
+import { PageHeader } from "../components/PageHeader";
 import { QuickArchive } from "../components/QuickArchive";
 
 export const HomePage = () => {
@@ -8,9 +10,7 @@ export const HomePage = () => {
   if (isLoading) {
     return (
       <div className="flex justify-center">
-        <div
-          className="w-full max-w-md rounded-3xl border border-slate-200 bg-white/95 p-6 text-center text-sm text-slate-500 shadow-sm"
-        >
+        <div className="w-full max-w-md rounded-2xl border border-slate-200 bg-white p-6 text-center text-sm text-slate-500">
           <p className="py-6">加载首页内容...</p>
         </div>
       </div>
@@ -28,19 +28,19 @@ export const HomePage = () => {
     {
       href: "/bookings",
       title: "导师预约",
-      description: "查看导师档案并快速预约合适的时间。",
+      description: "查看导师档案并快速预约合适时间",
       icon: "📅",
     },
     {
       href: "/resources",
       title: "资料共享",
-      description: "上传或下载学习资料，共享最新备考资源。",
+      description: "上传或下载学习资料，保持最新进度",
       icon: "📁",
     },
     {
       href: "/archive",
       title: "往期文章",
-      description: "查阅历史内容，回顾活动与学习总结。",
+      description: "查阅历史内容，回顾活动与总结",
       icon: "📰",
     },
   ];
@@ -63,104 +63,81 @@ export const HomePage = () => {
     },
   ];
 
-  const surfaceCardClasses =
-    "rounded-3xl border border-slate-200 bg-white/95 shadow-sm transition-shadow hover:shadow-md";
-
   return (
-    <div className="space-y-12">
-      <section className="grid gap-6 xl:grid-cols-[2fr_1.1fr]">
-        <div className="space-y-6">
-          {featured && (
-            <article className="relative overflow-hidden rounded-3xl border border-slate-200 bg-slate-950 text-white shadow-xl">
-              {featured.hero_image_url && (
-                <img
-                  src={featured.hero_image_url}
-                  alt={featured.title}
-                  className="absolute inset-0 h-full w-full object-cover opacity-60"
-                />
-              )}
-              <div className="absolute inset-0 bg-gradient-to-tr from-slate-950 via-slate-900/70 to-slate-900/10" />
-              <div className="absolute -right-24 top-16 h-64 w-64 rounded-full bg-accent/20 blur-3xl" aria-hidden="true" />
-              <div className="relative z-10 flex flex-col gap-4 p-8 md:p-12">
-                <span className="w-fit rounded-full bg-white/10 px-3 py-1 text-xs font-medium uppercase tracking-widest">
-                  精选文章
-                </span>
-                <h1 className="text-3xl font-semibold leading-tight md:text-4xl">{featured.title}</h1>
-                <p className="max-w-2xl text-sm text-slate-200 md:text-base">{featured.summary}</p>
-                <div className="flex flex-wrap items-center gap-4">
-                  <Link
-                    to={`/articles/${featured.slug}`}
-                    className="inline-flex items-center gap-2 rounded-full bg-accent px-5 py-2.5 text-sm font-semibold text-white shadow-lg shadow-accent/30 transition hover:bg-orange-500"
-                  >
-                    <span>阅读全文</span>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      viewBox="0 0 20 20"
-                      fill="none"
-                      stroke="currentColor"
-                      className="h-4 w-4"
-                      strokeWidth={1.5}
-                      aria-hidden="true"
-                    >
-                      <path d="m8 5 4 5-4 5" />
-                    </svg>
-                  </Link>
-                  <Link to="/archive" className="text-sm font-medium text-white/80 hover:text-white">
-                    浏览更多文章
-                  </Link>
-                </div>
-              </div>
-            </article>
-          )}
+    <div className="space-y-10">
+      <PageHeader
+        title="HFI 学习中心"
+        description="集中查看精选文章、导师预约与学习资料，帮助你高效安排每一步学习计划。"
+      />
 
-          {secondary.length > 0 && (
-            <div className="grid gap-4 sm:grid-cols-2">
-              {secondary.map((article) => (
-                <article
-                  key={article.id}
-                  className={`${surfaceCardClasses} h-full p-6`.trim()}
-                >
-                  <div className="flex h-full flex-col justify-between gap-4">
-                    <div className="space-y-3">
-                      <h2 className="text-lg font-semibold text-slate-900">{article.title}</h2>
-                      <p className="text-sm text-slate-600 line-clamp-3">{article.summary}</p>
-                    </div>
+      <section className="grid gap-6 lg:grid-cols-[2fr_1fr]">
+        <div className="space-y-6">
+          {featured ? (
+            <article className="rounded-2xl border border-slate-200 bg-white p-8">
+              <div className="flex flex-col gap-6 md:flex-row">
+                <div className="flex-1 space-y-4">
+                  <span className="inline-flex items-center rounded-full bg-primary/10 px-3 py-1 text-xs font-medium text-primary">
+                    精选文章
+                  </span>
+                  <h2 className="text-3xl font-semibold text-slate-900">{featured.title}</h2>
+                  <p className="text-sm text-slate-600 md:text-base">{featured.summary}</p>
+                  <div className="flex flex-wrap items-center gap-3 text-sm">
                     <Link
-                      to={`/articles/${article.slug}`}
-                      className="inline-flex items-center gap-2 text-sm font-medium text-primary transition hover:text-primary/80"
+                      to={`/articles/${featured.slug}`}
+                      className="inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-2 font-semibold text-white hover:bg-primary/90"
                     >
-                      阅读详情
+                      阅读全文
                       <svg
                         xmlns="http://www.w3.org/2000/svg"
                         viewBox="0 0 20 20"
                         fill="none"
                         stroke="currentColor"
-                        className="h-4 w-4"
                         strokeWidth={1.5}
-                        aria-hidden="true"
+                        className="h-4 w-4"
                       >
-                        <path d="m8 5 4 5-4 5" />
+                        <path d="m7.5 5 5 5-5 5" />
                       </svg>
                     </Link>
+                    <Link to="/archive" className="text-primary hover:text-primary/80">
+                      浏览更多文章
+                    </Link>
                   </div>
-                </article>
-              ))}
-            </div>
-          )}
-        </div>
+                </div>
+                {featured.hero_image_url ? (
+                  <div className="overflow-hidden rounded-xl border border-slate-100">
+                    <img
+                      src={featured.hero_image_url}
+                      alt={featured.title}
+                      className="h-full w-full max-h-64 object-cover"
+                    />
+                  </div>
+                ) : null}
+              </div>
+            </article>
+          ) : null}
 
-        <aside className="space-y-6">
-          <QuickArchive className="h-full" />
-          <div className={`${surfaceCardClasses} p-6`.trim()}>
+          {secondary.length > 0 ? (
+            <section className="rounded-2xl border border-slate-200 bg-white p-6">
+              <div className="flex items-center justify-between">
+                <h3 className="text-lg font-semibold text-slate-900">更多推荐</h3>
+                <Link to="/archive" className="text-sm text-primary hover:text-primary/80">
+                  查看全部
+                </Link>
+              </div>
+              <ArticleList articles={secondary} className="mt-4" showSummary />
+            </section>
+          ) : null}
+
+          <section className="rounded-2xl border border-slate-200 bg-white p-6">
             <h3 className="text-lg font-semibold text-slate-900">学习服务导航</h3>
-            <div className="mt-4 space-y-3">
+            <div className="mt-4 grid gap-3 sm:grid-cols-2">
               {guideLinks.map((link) => (
                 <Link
                   key={link.href}
                   to={link.href}
-                  className="group flex items-start gap-3 rounded-xl border border-transparent px-3 py-3 transition hover:border-primary/20 hover:bg-primary/5"
+                  className="group flex items-start gap-3 rounded-xl border border-slate-200 px-3 py-3 transition hover:border-primary/40 hover:bg-primary/5"
                 >
-                  <span className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 text-lg">
+                  <span className="flex h-10 w-10 items-center justify-center rounded-xl bg-primary/10 text-lg">
                     {link.icon}
                   </span>
                   <div className="flex-1">
@@ -181,89 +158,57 @@ export const HomePage = () => {
                 </Link>
               ))}
             </div>
-          </div>
+          </section>
+        </div>
+
+        <aside className="space-y-6">
+          <QuickArchive />
+          <section className="rounded-2xl border border-slate-200 bg-white p-6">
+            <h3 className="text-lg font-semibold text-slate-900">学习亮点</h3>
+            <ul className="mt-4 space-y-3 text-sm text-slate-600">
+              {highlightItems.map((item) => (
+                <li key={item.title} className="flex gap-3 rounded-xl border border-slate-200 px-3 py-3">
+                  <span className="text-lg">{item.icon}</span>
+                  <div>
+                    <p className="font-semibold text-slate-900">{item.title}</p>
+                    <p className="text-xs text-slate-500">{item.description}</p>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </section>
         </aside>
       </section>
 
-      <section className={`${surfaceCardClasses} p-8`.trim()}>
+      <section className="rounded-2xl border border-slate-200 bg-white p-6 md:p-8">
         <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
           <div>
-            <h2 className="text-2xl font-semibold text-slate-900">最新发布</h2>
-            <p className="text-sm text-slate-500">掌握学习中心的最新文章与公告动态</p>
+            <h3 className="text-2xl font-semibold text-slate-900">最新发布</h3>
+            <p className="text-sm text-slate-500">掌握学习中心的最新文章与公告动态。</p>
           </div>
-          <Link to="/archive" className="inline-flex items-center gap-2 text-sm font-medium text-primary hover:text-primary/80">
+          <Link to="/archive" className="text-sm font-medium text-primary hover:text-primary/80">
             浏览全部文章
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 20 20"
-              fill="none"
-              stroke="currentColor"
-              className="h-4 w-4"
-              strokeWidth={1.5}
-              aria-hidden="true"
-            >
-              <path d="m8 5 4 5-4 5" />
-            </svg>
           </Link>
         </div>
-        <div className="mt-6 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-          {data.latest.map((article) => (
-            <Link
-              to={`/articles/${article.slug}`}
-              key={article.id}
-              className="flex h-full flex-col justify-between rounded-2xl border border-slate-200 bg-white/90 p-5 transition hover:border-primary/20 hover:bg-primary/5"
-            >
-              <div className="space-y-2">
-                <h3 className="text-lg font-semibold text-slate-900">{article.title}</h3>
-                <p className="text-sm text-slate-600 line-clamp-3">{article.summary}</p>
-              </div>
-              <span className="mt-3 block text-xs text-slate-400">
-                {article.published_at ? new Date(article.published_at).toLocaleString() : ""}
-              </span>
-            </Link>
-          ))}
-        </div>
+        <ArticleList articles={data.latest} className="mt-6" />
       </section>
 
-      <section className="grid gap-6 lg:grid-cols-[1.4fr_1fr]">
-        <div className={`${surfaceCardClasses} p-8`.trim()}>
-          <h2 className="text-2xl font-semibold text-slate-900">公告栏</h2>
-          <div className="mt-6 space-y-4">
-            {data.announcements.length > 0 ? (
-              data.announcements.map((announcement) => (
-                <article key={announcement.id} className="rounded-2xl border border-slate-200/80 p-5 transition hover:border-primary/30">
-                  <p className="text-xs font-medium uppercase tracking-wide text-primary">
-                    {new Date(announcement.published_at).toLocaleString()}
-                  </p>
-                  <h3 className="mt-2 text-lg font-semibold text-slate-900">{announcement.title}</h3>
-                  <p className="mt-1 text-sm text-slate-600">{announcement.content}</p>
-                </article>
-              ))
-            ) : (
-              <p className="text-sm text-slate-500">暂无公告</p>
-            )}
-          </div>
-        </div>
-        <div className={`rounded-3xl border border-slate-200 bg-gradient-to-br from-primary/5 via-white to-accent/10 p-8 shadow-sm transition-shadow hover:shadow-md`}>
-          <h3 className="text-lg font-semibold text-slate-900">校园服务亮点</h3>
-          <p className="mt-2 text-sm text-slate-600">
-            我们将活动、预约与资料同步在学习中心，随时随地保持学习节奏。
-          </p>
-          <ul className="mt-5 space-y-4">
-            {highlightItems.map((item) => (
-              <li key={item.title} className="flex items-start gap-3">
-                <span className="flex h-10 w-10 items-center justify-center rounded-full bg-white text-lg shadow-sm">
-                  {item.icon}
-                </span>
-                <div>
-                  <p className="text-sm font-semibold text-slate-900">{item.title}</p>
-                  <p className="text-xs text-slate-600">{item.description}</p>
-                </div>
+      {data.announcements.length > 0 ? (
+        <section className="rounded-2xl border border-slate-200 bg-white p-6">
+          <h3 className="text-lg font-semibold text-slate-900">学习中心公告</h3>
+          <ul className="mt-4 space-y-3">
+            {data.announcements.map((announcement) => (
+              <li key={announcement.id} className="rounded-xl border border-slate-200 p-4">
+                <p className="text-sm font-medium text-slate-900">{announcement.title}</p>
+                <p className="mt-1 text-xs text-slate-400">
+                  发布于 {new Date(announcement.published_at).toLocaleDateString()}
+                </p>
+                <p className="mt-2 text-sm text-slate-600">{announcement.content}</p>
               </li>
             ))}
           </ul>
-        </div>
-      </section>
+        </section>
+      ) : null}
     </div>
   );
 };

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -24,18 +24,23 @@ export const LoginPage = () => {
   };
 
   return (
-    <div className="mx-auto max-w-md rounded-2xl bg-white p-8 shadow-lg">
-      <h1 className="text-2xl font-semibold text-slate-800">登录 HFI 账号</h1>
-      <p className="mt-2 text-sm text-slate-500">未登录也可浏览文章，但预约与上传功能仅对登录用户开放。</p>
+    <div className="mx-auto flex w-full max-w-md flex-col gap-6">
+      <div className="space-y-2 text-center">
+        <h1 className="text-3xl font-semibold text-slate-900">登录 HFI 账号</h1>
+        <p className="text-sm text-slate-500">未登录也可浏览文章，但预约与上传功能仅对登录用户开放。</p>
+      </div>
 
-      <form onSubmit={handleSubmit} className="mt-6 space-y-4">
+      <form
+        onSubmit={handleSubmit}
+        className="rounded-2xl border border-slate-200 bg-white p-6 space-y-4"
+      >
         <div>
           <label className="text-sm font-medium text-slate-700">邮箱</label>
           <input
             type="email"
             value={email}
             onChange={(event) => setEmail(event.target.value)}
-            className="mt-1 w-full rounded border border-slate-300 px-3 py-2 focus:border-primary focus:outline-none"
+            className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 focus:border-primary focus:outline-none"
             required
           />
         </div>
@@ -45,18 +50,18 @@ export const LoginPage = () => {
             type="password"
             value={password}
             onChange={(event) => setPassword(event.target.value)}
-            className="mt-1 w-full rounded border border-slate-300 px-3 py-2 focus:border-primary focus:outline-none"
+            className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 focus:border-primary focus:outline-none"
             required
           />
         </div>
         {(error || formError) && (
-          <div className="rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-600">
+          <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-600">
             {formError ?? error}
           </div>
         )}
         <button
           type="submit"
-          className="w-full rounded bg-primary px-4 py-2 font-semibold text-white hover:bg-primary/90 disabled:opacity-60"
+          className="w-full rounded-lg bg-primary px-4 py-2 font-semibold text-white hover:bg-primary/90 disabled:opacity-60"
           disabled={isLoading}
         >
           {isLoading ? "登录中..." : "登录"}

--- a/frontend/src/pages/ResourcesPage.tsx
+++ b/frontend/src/pages/ResourcesPage.tsx
@@ -7,6 +7,7 @@ import {
   useUploadResource,
   useDownloadResource,
 } from "../api/hooks";
+import { PageHeader } from "../components/PageHeader";
 
 export const ResourcesPage = () => {
   const { user } = useAuthStore();
@@ -53,108 +54,117 @@ export const ResourcesPage = () => {
   };
 
   return (
-    <div className="grid gap-8 lg:grid-cols-[2fr_1fr]">
-      <section className="space-y-6">
-        <header>
-          <h1 className="text-3xl font-semibold text-slate-800">资料共享</h1>
-          <p className="mt-2 text-sm text-slate-500">浏览已审核的学习资料，或上传自己的文件等待审核。</p>
-        </header>
+    <div className="space-y-8">
+      <PageHeader
+        title="资料共享"
+        description="浏览已审核的学习资料，或上传自己的文件等待审核。"
+      />
 
-        <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-          <h2 className="text-xl font-semibold text-slate-800">公开资料</h2>
-          <div className="mt-4 space-y-3">
-            {publicResources && publicResources.length > 0 ? (
-              publicResources.map((resource) => (
-                <div key={resource.id} className="flex flex-col gap-1 rounded border border-slate-200 p-4 sm:flex-row sm:items-center sm:justify-between">
-                  <div>
-                    <p className="font-medium text-slate-700">{resource.title}</p>
-                    <p className="text-sm text-slate-500">{resource.description}</p>
-                    <p className="text-xs text-slate-400">上传时间：{new Date(resource.created_at).toLocaleString()}</p>
-                  </div>
-                  <button
-                    onClick={() => handleDownload(resource.id)}
-                    className="mt-2 rounded bg-primary px-3 py-1 text-sm text-white hover:bg-primary/90 sm:mt-0"
+      <div className="grid gap-6 lg:grid-cols-[1.6fr_1fr]">
+        <section className="space-y-6">
+          <div className="rounded-2xl border border-slate-200 bg-white p-6">
+            <h2 className="text-lg font-semibold text-slate-900">公开资料</h2>
+            <div className="mt-4 space-y-3">
+              {publicResources && publicResources.length > 0 ? (
+                publicResources.map((resource) => (
+                  <div
+                    key={resource.id}
+                    className="flex flex-col gap-2 rounded-xl border border-slate-200 p-4 text-sm text-slate-600 sm:flex-row sm:items-center sm:justify-between"
                   >
-                    下载
-                  </button>
-                </div>
-              ))
-            ) : (
-              <p className="text-sm text-slate-500">暂无公开资料</p>
-            )}
-          </div>
-        </div>
-
-        {user && (
-          <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-            <h2 className="text-xl font-semibold text-slate-800">上传资料</h2>
-            <form onSubmit={handleUpload} className="mt-4 space-y-4">
-              <div>
-                <label className="text-sm font-medium text-slate-700">标题</label>
-                <input
-                  value={title}
-                  onChange={(event) => setTitle(event.target.value)}
-                  className="mt-1 w-full rounded border border-slate-300 px-3 py-2"
-                  required
-                />
-              </div>
-              <div>
-                <label className="text-sm font-medium text-slate-700">描述</label>
-                <textarea
-                  value={description}
-                  onChange={(event) => setDescription(event.target.value)}
-                  className="mt-1 w-full rounded border border-slate-300 px-3 py-2"
-                  rows={3}
-                />
-              </div>
-              <div>
-                <label className="text-sm font-medium text-slate-700">选择文件</label>
-                <input type="file" ref={fileInputRef} className="mt-1 block w-full" required />
-              </div>
-              {uploadMessage && (
-                <div className="rounded bg-slate-100 px-4 py-2 text-sm text-slate-600">{uploadMessage}</div>
-              )}
-              <button
-                type="submit"
-                className="w-full rounded bg-accent px-4 py-2 font-semibold text-white hover:bg-orange-500 disabled:opacity-60"
-                disabled={uploadMutation.isPending}
-              >
-                {uploadMutation.isPending ? "上传中..." : "提交审核"}
-              </button>
-            </form>
-          </div>
-        )}
-
-        {user && (
-          <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-            <h2 className="text-xl font-semibold text-slate-800">我的上传记录</h2>
-            <div className="mt-3 space-y-3">
-              {myResources && myResources.length > 0 ? (
-                myResources.map((resource) => (
-                  <div key={resource.id} className="rounded border border-slate-200 p-4">
-                    <p className="font-medium text-slate-700">{resource.title}</p>
-                    <p className="text-sm text-slate-500">状态：{resource.status}</p>
-                    <p className="text-xs text-slate-400">{new Date(resource.created_at).toLocaleString()}</p>
+                    <div className="space-y-1">
+                      <p className="font-medium text-slate-800">{resource.title}</p>
+                      <p className="text-xs text-slate-500">{resource.description}</p>
+                      <p className="text-xs text-slate-400">
+                        上传时间：{new Date(resource.created_at).toLocaleString()}
+                      </p>
+                    </div>
+                    <button
+                      onClick={() => handleDownload(resource.id)}
+                      className="rounded-lg bg-primary px-3 py-1.5 text-sm font-medium text-white hover:bg-primary/90"
+                    >
+                      下载
+                    </button>
                   </div>
                 ))
               ) : (
-                <p className="text-sm text-slate-500">暂无上传记录</p>
+                <p className="text-sm text-slate-500">暂无公开资料</p>
               )}
             </div>
           </div>
-        )}
-      </section>
 
-      <aside className="space-y-4">
-        <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-          <h3 className="text-lg font-semibold text-slate-800">审核流程</h3>
-          <ol className="mt-3 space-y-2 text-sm text-slate-600">
-            <li>1. 上传资料后进入待审核列表</li>
-            <li>2. 管理员在后台进行审批</li>
-            <li>3. 审核通过后所有人可下载</li>
-          </ol>
-        </div>
-      </aside>
+          {user ? (
+            <div className="rounded-2xl border border-slate-200 bg-white p-6">
+              <h2 className="text-lg font-semibold text-slate-900">上传资料</h2>
+              <form onSubmit={handleUpload} className="mt-4 space-y-4 text-sm text-slate-700">
+                <div>
+                  <label className="text-sm font-medium text-slate-700">标题</label>
+                  <input
+                    value={title}
+                    onChange={(event) => setTitle(event.target.value)}
+                    className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2"
+                    required
+                  />
+                </div>
+                <div>
+                  <label className="text-sm font-medium text-slate-700">描述</label>
+                  <textarea
+                    value={description}
+                    onChange={(event) => setDescription(event.target.value)}
+                    className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2"
+                    rows={3}
+                  />
+                </div>
+                <div>
+                  <label className="text-sm font-medium text-slate-700">选择文件</label>
+                  <input type="file" ref={fileInputRef} className="mt-1 block w-full text-sm" required />
+                </div>
+                {uploadMessage ? (
+                  <div className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-2 text-sm text-slate-600">
+                    {uploadMessage}
+                  </div>
+                ) : null}
+                <button
+                  type="submit"
+                  className="w-full rounded-lg bg-accent px-4 py-2 font-semibold text-white hover:bg-orange-500 disabled:opacity-60"
+                  disabled={uploadMutation.isPending}
+                >
+                  {uploadMutation.isPending ? "上传中..." : "提交审核"}
+                </button>
+              </form>
+            </div>
+          ) : null}
+
+          {user ? (
+            <div className="rounded-2xl border border-slate-200 bg-white p-6">
+              <h2 className="text-lg font-semibold text-slate-900">我的上传记录</h2>
+              <div className="mt-3 space-y-3">
+                {myResources && myResources.length > 0 ? (
+                  myResources.map((resource) => (
+                    <div key={resource.id} className="rounded-xl border border-slate-200 p-4 text-sm text-slate-600">
+                      <p className="font-medium text-slate-800">{resource.title}</p>
+                      <p className="text-xs text-slate-500">状态：{resource.status}</p>
+                      <p className="text-xs text-slate-400">{new Date(resource.created_at).toLocaleString()}</p>
+                    </div>
+                  ))
+                ) : (
+                  <p className="text-sm text-slate-500">暂无上传记录</p>
+                )}
+              </div>
+            </div>
+          ) : null}
+        </section>
+
+        <aside className="space-y-4">
+          <div className="rounded-2xl border border-slate-200 bg-white p-6 text-sm text-slate-600">
+            <h3 className="text-lg font-semibold text-slate-900">审核流程</h3>
+            <ol className="mt-3 space-y-2">
+              <li>1. 上传资料后进入待审核列表</li>
+              <li>2. 管理员在后台进行审批</li>
+              <li>3. 审核通过后所有人可下载</li>
+            </ol>
+          </div>
+        </aside>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add shared PageHeader and ArticleList components plus a cn helper to support reusable flat UI patterns
- rebuild the main layout and core pages (home, archive, article detail, bookings, resources, admin, login) with the new design system for a cohesive flat aesthetic
- refresh QuickArchive and base styling while updating the lockfile to ensure Tailwind/PostCSS tooling works with the new layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca8b4dc7b88322bf74f5705491a799